### PR TITLE
Clean up mobile clerk integration, fix type errors

### DIFF
--- a/apps/expo/src/_app.tsx
+++ b/apps/expo/src/_app.tsx
@@ -7,13 +7,11 @@ import { HomeScreen } from "./screens/home";
 import { SignInSignUpScreen } from "./screens/signin";
 import { ClerkProvider, SignedIn, SignedOut } from "@clerk/clerk-expo";
 import { tokenCache } from "./utils/cache";
-
-// Find this in your Dashboard.
-const clerk_frontend_api = "YOUR_CLERK_FRONTEND_API";
+import { CLERK_FRONTEND_API } from "./constants";
 
 export const App = () => {
   return (
-    <ClerkProvider frontendApi={clerk_frontend_api} tokenCache={tokenCache}>
+    <ClerkProvider frontendApi={CLERK_FRONTEND_API} tokenCache={tokenCache}>
       <SignedIn>
         <TRPCProvider>
           <SafeAreaProvider>

--- a/apps/expo/src/constants.ts
+++ b/apps/expo/src/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * URL key for the Clerk auth API. You can find this in your Clerk dashboard:
+ * https://dashboard.clerk.dev
+ *
+ * NOTE: we recommend putting the frontend api key here instead of in your .env
+ * files for two reasons:
+ * 1. It's okay for this to be "public" (CLERK_API_KEY and CLERK_JWT_KEY should
+ *    NEVER be public)
+ * 2. Parsing the .env file in Metro/Expo runs the risk of including the
+ *    variables above that we don't want (and it's obnoxious to do right as a
+ *    result)
+ */
+export const CLERK_FRONTEND_API = "";
+
+if (CLERK_FRONTEND_API === "") {
+  throw new Error("CLERK_FRONTEND_API is not defined");
+}

--- a/apps/expo/src/utils/trpc.tsx
+++ b/apps/expo/src/utils/trpc.tsx
@@ -45,7 +45,7 @@ export const TRPCProvider: React.FC<{
           async headers() {
             const authToken = await getToken();
             return {
-              Authorization: authToken,
+              Authorization: authToken ?? undefined,
             };
           },
           url: `${getBaseUrl()}/api/trpc`,


### PR DESCRIPTION
I really wanted to get env variables passing through to expo but it ended up being chaos. Almost made a separate package just to pass around the shared api key but then couldn't figure out how it was passed in Next outside of the .env lol