### PR TITLE
Update package.json to use local workspace references for pnpm packages

### DIFF
--- a/apps/expo/package.json
+++ b/apps/expo/package.json
@@ -12,8 +12,8 @@
         "lint": "eslint . --ext ts,tsx"
     },
     "dependencies": {
-        "@acme/api": "*",
-        "@acme/tailwind-config": "*",
+        "@acme/api": "workspace:*",
+        "@acme/tailwind-config": "workspace:*",
         "@clerk/clerk-expo": "^0.17.7",
         "@shopify/flash-list": "^1.4.0",
         "@tanstack/react-query": "^4.16.1",

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -12,9 +12,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/api": "*",
-    "@acme/db": "*",
-    "@acme/tailwind-config": "*",
+    "@acme/api": "workspace:*",
+    "@acme/db": "workspace:*",
+    "@acme/tailwind-config": "workspace:*",
     "@clerk/nextjs": "^4.29.3",
     "@tanstack/react-query": "^4.16.1",
     "@trpc/client": "^10.1.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@acme/db": "*",
+    "@acme/db": "workspace:*",
     "@trpc/client": "^10.1.0",
     "@trpc/server": "^10.1.0",
     "superjson": "^1.9.1",


### PR DESCRIPTION
Updated package.json files to utilise local workspace references (workspace:\*) instead of global versions (\*) for @acmi/* packages to ensure that pnpm correctly resolves dependencies from local sources.